### PR TITLE
Rewrite unduplicate command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,9 @@
   "type": "typo3-cms-extension",
   "description": "Finds duplicates in sys_file and unduplicates them",
   "require": {
-    "typo3/cms-core": "^8.7",
-    "php": ">=7.0.0"
+    "php": ">=7.0.0",
+    "ext-pdo": "*",
+    "typo3/cms-core": "^8.7"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
   "name": "elementareteilchen/unduplicator",
   "type": "typo3-cms-extension",
-  "version": "0.1.0",
   "description": "Finds duplicates in sys_file and unduplicates them",
   "require": {
     "typo3/cms-core": "^8.7",


### PR DESCRIPTION
The UnduplicateCommand is rewritten to

- find references in sys_reference database table
- use Doctrine QueryBuilders
- add a `--dry-run` option to see results without database changes